### PR TITLE
Improve Coding Standard Checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor/
 composer.lock
 .phpunit.result.cache
+coverage.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,34 @@
 language: php
-
 matrix:
   fast_finish: true
   include:
-    - php: 7.1
+    -
+      php: 7.1
       env:
-       - COMPOSER_ARG=--prefer-lowest
-    - php: 7.4
-    - php: nightly
+        - PHPUNIT_TEST=1
+        - COMPOSER_ARG=--prefer-lowest
+    -
+      php: 7.4
+    -
+      php: nightly
       env:
-       - COMPOSER_ARG=--ignore-platform-reqs
+        - COMPOSER_ARG=--ignore-platform-reqs
+    -
+      php: 7.4
+      env:
+        - LINT_CHECK=1
+        - PHPCS_TEST=1
+        - DUPLICATE_CODE_CHECK=1
+        - PHPSTAN_TEST=1
 
 before_script:
-  - composer validate
-  - composer update $COMPOSER_ARG --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile
+  - 'composer validate'
+  - 'composer update $COMPOSER_ARG --no-interaction --no-progress --no-suggest --optimize-autoloader --verbose --profile'
+  - 'if [[ $DUPLICATE_CODE_CHECK ]]; then sudo apt remove -y nodejs && curl -sL https://deb.nodesource.com/setup_14.x -o nodesource_setup.sh && sudo bash nodesource_setup.sh && sudo apt install -y build-essential nodejs  && npm install jscpd@3.2.1  ;fi'
 
 script:
-  - vendor/bin/phpunit
-  - vendor/bin/phpcs src tests
+  - 'if [[ $LINT_CHECK ]]; then composer lint; fi'
+  - 'if [[ $PHPCS_TEST ]]; then composer phpcs; fi'
+  - 'if [[ $PHPSTAN_TEST ]]; then composer phpstan; fi'
+  - 'if [[ $PHPUNIT_TEST ]]; composer test; fi'
+  - 'if [[ $DUPLICATE_CODE_CHECK ]]; then node_modules/jscpd/bin/jscpd -t 1 src; fi'

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,12 @@ matrix:
         - COMPOSER_ARG=--prefer-lowest
     -
       php: 7.4
+      env:
+        - PHPUNIT_COVERAGE_TEST=1
     -
       php: nightly
       env:
+        - PHPUNIT_TEST=1
         - COMPOSER_ARG=--ignore-platform-reqs
     -
       php: 7.4
@@ -30,5 +33,9 @@ script:
   - 'if [[ $LINT_CHECK ]]; then composer lint; fi'
   - 'if [[ $PHPCS_TEST ]]; then composer phpcs; fi'
   - 'if [[ $PHPSTAN_TEST ]]; then composer phpstan; fi'
-  - 'if [[ $PHPUNIT_TEST ]]; composer test; fi'
+  - 'if [[ $PHPUNIT_COVERAGE_TEST ]]; then composer test-coverage; fi'
+  - 'if [[ $PHPUNIT_TEST ]]; then composer test; fi'
   - 'if [[ $DUPLICATE_CODE_CHECK ]]; then node_modules/jscpd/bin/jscpd -t 1 src; fi'
+
+after_script:
+  - 'if [[ $PHPUNIT_COVERAGE_TEST ]]; then bash <(curl -s https://codecov.io/bash) -f coverage.xml; fi'

--- a/README.md
+++ b/README.md
@@ -1,7 +1,19 @@
-sminnee/callbacklist
-====================
+# sminnee/callbacklist
 
-[![Build Status](https://api.travis-ci.org/sminnee/callbacklist.svg?branch=master)](https://travis-ci.org/sminnee/callbacklist)
+[![Build Status](https://travis-ci.org/sminnee/callbacklist.svg?branch=master)](https://travis-ci.org/sminnee/callbacklist)
+[![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/sminnee/callbacklist/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/sminnee/callbacklist/?branch=master)
+[![codecov.io](https://codecov.io/github/sminnee/callbacklist/coverage.svg?branch=master)](https://codecov.io/github/sminnee/callbacklist?branch=master)
+
+[![Latest Stable Version](https://poser.pugx.org/sminnee/callbacklist/version)](https://packagist.org/packages/sminnee/callbacklist)
+[![License](https://poser.pugx.org/sminnee/callbacklist/license)](https://packagist.org/packages/sminnee/callbacklist)
+[![Monthly Downloads](https://poser.pugx.org/sminnee/callbacklist/d/monthly)](https://packagist.org/packages/sminnee/callbacklist)
+
+[![GitHub Code Size](https://img.shields.io/github/languages/code-size/sminnee/callbacklist)](https://github.com/sminnee/callbacklist)
+[![GitHub Last Commit](https://img.shields.io/github/last-commit/sminnee/callbacklist)](https://github.com/sminnee/callbacklist)
+[![GitHub Activity](https://img.shields.io/github/commit-activity/m/sminnee/callbacklist)](https://github.com/sminnee/callbacklist)
+[![GitHub Issues](https://img.shields.io/github/issues/sminnee/callbacklist)](https://github.com/sminnee/callbacklist/issues)
+
+![codecov.io](https://codecov.io/github/sminnee/callbacklist/branch.svg?branch=master)
 
 This micropackage provides a simple class for managing a list of callbacks.
 

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
         "lint": "vendor/bin/parallel-lint src/ tests/",
         "phpstan": "vendor/bin/phpstan analyse --level=8 -c tests\/phpstan.neon src/",
         "check": "composer lint && composer phpcs && composer phpstan",
-        "test": "vendor/bin/phpunit"
+        "test": "vendor/bin/phpunit",
+        "test-coverage": "phpdbg -qrr vendor/bin/phpunit tests --coverage-clover=coverage.xml '''' flush=all"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "sminnee/callbacklist",
+    "name": "sminnee\/callbacklist",
     "description": "PHP class that manages a list of callbacks",
     "type": "library",
     "license": "MIT",
@@ -14,11 +14,23 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^7 || ^8 || ^9",
-        "squizlabs/php_codesniffer": "^3.5"
+        "squizlabs/php_codesniffer": "^3.5",
+        "slevomat/coding-standard": "^6.4",
+        "php-parallel-lint/php-parallel-lint": "^1.2",
+        "php-parallel-lint/php-console-highlighter": "^0.5.0",
+        "phpstan/phpstan-strict-rules": "^0.12.5"
     },
     "autoload": {
         "psr-4": {
-            "Sminnee\\CallbackList\\": "src/"
+            "Sminnee\\CallbackList\\": "src\/"
         }
+    },
+    "scripts": {
+        "phpcs": "vendor/bin/phpcs --standard=ruleset.xml --extensions=php --tab-width=4 -sp src tests",
+        "phpcbf": "vendor/bin/phpcbf --standard=ruleset.xml --extensions=php --tab-width=4 -sp src tests",
+        "lint": "vendor/bin/parallel-lint src/ tests/",
+        "phpstan": "vendor/bin/phpstan analyse --level=8 -c tests\/phpstan.neon src/",
+        "check": "composer lint && composer phpcs && composer phpstan",
+        "test": "vendor/bin/phpunit"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,24 @@
-<phpunit colors="true">
-    <testsuite name="Default">
-        <directory>tests</directory>
-    </testsuite>
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         executionOrder="depends,defects"
+         forceCoversAnnotation="true"
+         beStrictAboutCoversAnnotation="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutTodoAnnotatedTests="true"
+         failOnRisky="true"
+         failOnWarning="true"
+         verbose="true">
+    <testsuites>
+        <testsuite name="default">
+            <directory suffix="Test.php">tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <coverage processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+    </coverage>
 </phpunit>

--- a/ruleset.xml
+++ b/ruleset.xml
@@ -1,0 +1,159 @@
+<?xml version="1.0"?>
+<ruleset name="YOUR_PROJECT">
+	<config name="installed_paths" value="../../slevomat/coding-standard"/><!-- relative path from PHPCS source location -->
+
+	<rule ref="PSR2"/>
+	<rule ref="SlevomatCodingStandard.Arrays.TrailingArrayComma"/>
+	<rule ref="SlevomatCodingStandard.Arrays.MultiLineArrayEndBracketPlacement"/>
+	<rule ref="SlevomatCodingStandard.Arrays.DisallowImplicitArrayCreation"/>
+	<rule ref="SlevomatCodingStandard.Arrays.SingleLineArrayWhitespace"/>
+
+
+	<rule ref="SlevomatCodingStandard.Classes.TraitUseDeclaration"/>
+	<rule ref="SlevomatCodingStandard.Classes.RequireSingleLineMethodSignature"/>
+	<rule ref="SlevomatCodingStandard.Classes.DisallowMultiPropertyDefinition"/>
+	<rule ref="SlevomatCodingStandard.Classes.SuperfluousExceptionNaming"/>
+	<rule ref="SlevomatCodingStandard.Classes.ModernClassNameReference"/>
+	<rule ref="SlevomatCodingStandard.Classes.ConstantSpacing"/>
+	<rule ref="SlevomatCodingStandard.Classes.ClassStructure"/>
+	<rule ref="SlevomatCodingStandard.Classes.ClassConstantVisibility"/>
+	<rule ref="SlevomatCodingStandard.Classes.RequireMultiLineMethodSignature"/>
+	<rule ref="SlevomatCodingStandard.Classes.SuperfluousInterfaceNaming"/>
+	<rule ref="SlevomatCodingStandard.Classes.PropertySpacing"/>
+	<!-- <rule ref="SlevomatCodingStandard.Classes.EmptyLinesAroundClassBraces"/> -->
+	<rule ref="SlevomatCodingStandard.Classes.DisallowLateStaticBindingForConstants"/>
+	<rule ref="SlevomatCodingStandard.Classes.SuperfluousAbstractClassNaming"/>
+	<rule ref="SlevomatCodingStandard.Classes.ParentCallSpacing"/>
+	<!-- <rule ref="SlevomatCodingStandard.Classes.UnusedPrivateElements"/> -->
+	<rule ref="SlevomatCodingStandard.Classes.TraitUseSpacing"/>
+	<rule ref="SlevomatCodingStandard.Classes.MethodSpacing">
+		<properties>
+			<property name="minLinesCount" value="2"/>
+			<property name="maxLinesCount" value="2"/>
+		</properties>
+	</rule>
+	<rule ref="SlevomatCodingStandard.Classes.SuperfluousTraitNaming"/>
+	<rule ref="SlevomatCodingStandard.Classes.DisallowMultiConstantDefinition"/>
+
+	<!-- this fails even it is the only rule
+	<rule ref="SlevomatCodingStandard.Classes.ClassMemberSpacing"/>
+	-->
+
+	<rule ref="SlevomatCodingStandard.Classes.UselessLateStaticBinding"/>
+
+
+	<rule ref="SlevomatCodingStandard.Commenting.UselessInheritDocComment" />
+	<!-- <rule ref="SlevomatCodingStandard.Commenting.DisallowOneLinePropertyDocComment" /> -->
+	<rule ref="SlevomatCodingStandard.Commenting.UselessFunctionDocComment" />
+	<rule ref="SlevomatCodingStandard.Commenting.RequireOneLineDocComment" />
+	<rule ref="SlevomatCodingStandard.Commenting.ForbiddenComments" />
+	<rule ref="SlevomatCodingStandard.Commenting.RequireOneLinePropertyDocComment" />
+	<rule ref="SlevomatCodingStandard.Commenting.EmptyComment" />
+	<rule ref="SlevomatCodingStandard.Commenting.DocCommentSpacing" />
+	<rule ref="SlevomatCodingStandard.Commenting.InlineDocCommentDeclaration" />
+	<rule ref="SlevomatCodingStandard.Commenting.DisallowCommentAfterCode" />
+	<rule ref="SlevomatCodingStandard.Commenting.ForbiddenAnnotations" />
+
+
+	<rule ref="SlevomatCodingStandard.ControlStructures.DisallowYodaComparison"/>
+	<rule ref="SlevomatCodingStandard.ControlStructures.UselessIfConditionWithReturn"/>
+
+	<rule ref="SlevomatCodingStandard.ControlStructures.DisallowShortTernaryOperator"/>
+	<rule ref="SlevomatCodingStandard.ControlStructures.RequireShortTernaryOperator"/>
+	<rule ref="SlevomatCodingStandard.ControlStructures.RequireMultiLineTernaryOperator"/>
+	<rule ref="SlevomatCodingStandard.ControlStructures.DisallowContinueWithoutIntegerOperandInSwitch"/>
+	<rule ref="SlevomatCodingStandard.ControlStructures.EarlyExit"/>
+
+
+	<rule ref="SlevomatCodingStandard.ControlStructures.AssignmentInCondition"/>
+	<rule ref="SlevomatCodingStandard.ControlStructures.NewWithParentheses"/>
+	<!-- <rule ref="SlevomatCodingStandard.ControlStructures.RequireNullCoalesceOperator"/> -->
+	<!-- <rule ref="SlevomatCodingStandard.ControlStructures.RequireYodaComparison"/> -->
+	<rule ref="SlevomatCodingStandard.ControlStructures.UselessTernaryOperator"/>
+	<rule ref="SlevomatCodingStandard.ControlStructures.RequireNullCoalesceEqualOperator"/>
+	<!-- <rule ref="SlevomatCodingStandard.ControlStructures.NewWithoutParentheses"/> -->
+	<!-- <rule ref="SlevomatCodingStandard.ControlStructures.BlockControlStructureSpacing"/> -->
+
+
+	<rule ref="SlevomatCodingStandard.ControlStructures.JumpStatementsSpacing"/>
+	<rule ref="SlevomatCodingStandard.ControlStructures.RequireTernaryOperator"/>
+	<rule ref="SlevomatCodingStandard.ControlStructures.LanguageConstructWithParentheses"/>
+	<rule ref="SlevomatCodingStandard.ControlStructures.DisallowEmpty"/>
+
+	<!-- <rule ref="SlevomatCodingStandard.Files.TypeNameMatchesFileName"/> -->
+	<rule ref="SlevomatCodingStandard.Files.LineLength"/>
+
+	<rule ref="SlevomatCodingStandard.Exceptions.ReferenceThrowableOnly"/>
+	<rule ref="SlevomatCodingStandard.Exceptions.DeadCatch"/>
+
+	<rule ref="SlevomatCodingStandard.Functions.DisallowArrowFunction"/>
+	<!-- <rule ref="SlevomatCodingStandard.Functions.RequireArrowFunction"/> -->
+	<rule ref="SlevomatCodingStandard.Functions.DisallowEmptyFunction"/>
+	<!-- <rule ref="SlevomatCodingStandard.Functions.TrailingCommaInCall"/> -->
+	<rule ref="SlevomatCodingStandard.Functions.StrictCall"/>
+	<rule ref="SlevomatCodingStandard.Functions.UnusedInheritedVariablePassedToClosure"/>
+	<rule ref="SlevomatCodingStandard.Functions.UselessParameterDefaultValue"/>
+	<rule ref="SlevomatCodingStandard.Functions.UnusedParameter"/>
+	<rule ref="SlevomatCodingStandard.Functions.ArrowFunctionDeclaration"/>
+	<rule ref="SlevomatCodingStandard.Functions.StaticClosure"/>
+
+
+	<rule ref="SlevomatCodingStandard.Namespaces.FullyQualifiedClassNameInAnnotation"/>
+	<rule ref="SlevomatCodingStandard.Namespaces.UseSpacing"/>
+	<rule ref="SlevomatCodingStandard.Namespaces.MultipleUsesPerLine"/>
+<!--	<rule ref="SlevomatCodingStandard.Namespaces.FullyQualifiedExceptions"/> -->
+<!--	<rule ref="SlevomatCodingStandard.Namespaces.UseOnlyWhitelistedNamespaces"/> -->
+	<rule ref="SlevomatCodingStandard.Namespaces.UseDoesNotStartWithBackslash"/>
+<!--	<rule ref="SlevomatCodingStandard.Namespaces.ReferenceUsedNamesOnly"/> -->
+	<rule ref="SlevomatCodingStandard.Namespaces.UnusedUses"/>
+	<rule ref="SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses"/>
+	<rule ref="SlevomatCodingStandard.Namespaces.DisallowGroupUse"/>
+	<rule ref="SlevomatCodingStandard.Namespaces.FullyQualifiedGlobalConstants"/>
+	<rule ref="SlevomatCodingStandard.Namespaces.FullyQualifiedClassNameAfterKeyword"/>
+	<rule ref="SlevomatCodingStandard.Namespaces.FullyQualifiedGlobalFunctions"/>
+	<rule ref="SlevomatCodingStandard.Namespaces.NamespaceDeclaration"/>
+	<rule ref="SlevomatCodingStandard.Namespaces.UselessAlias"/>
+	<rule ref="SlevomatCodingStandard.Namespaces.RequireOneNamespaceInFile"/>
+	<rule ref="SlevomatCodingStandard.Namespaces.NamespaceSpacing"/>
+	<rule ref="SlevomatCodingStandard.Namespaces.UseFromSameNamespace"/>
+
+	<rule ref="SlevomatCodingStandard.Numbers.DisallowNumericLiteralSeparator"/>
+	<!-- <rule ref="SlevomatCodingStandard.Numbers.RequireNumericLiteralSeparator"/> -->
+
+
+	<rule ref="SlevomatCodingStandard.Operators.RequireOnlyStandaloneIncrementAndDecrementOperators"/>
+	<rule ref="SlevomatCodingStandard.Operators.RequireCombinedAssignmentOperator"/>
+	<rule ref="SlevomatCodingStandard.Operators.SpreadOperatorSpacing"/>
+	<rule ref="SlevomatCodingStandard.Operators.DisallowEqualOperators"/>
+	<rule ref="SlevomatCodingStandard.Operators.NegationOperatorSpacing"/>
+	<!-- <rule ref="SlevomatCodingStandard.Operators.DisallowIncrementAndDecrementOperators"/> -->
+
+	<rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHintSpacing"/>
+	<rule ref="SlevomatCodingStandard.TypeHints.NullTypeHintOnLastPosition"/>
+	<rule ref="SlevomatCodingStandard.TypeHints.UselessConstantTypeHint"/>
+	<rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHint">
+		<properties>
+			<!-- this needs PHP 7.2_ -->
+			<property name="enableObjectTypeHint" value="false"/>
+		</properties>
+	</rule>
+	<rule ref="SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue"/>
+	<!-- This is not compatible with PHP < 7.4
+	<rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint"/>
+	-->
+	<rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHintSpacing"/>
+	<rule ref="SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint"/>
+	<rule ref="SlevomatCodingStandard.TypeHints.DisallowArrayTypeHintSyntax"/>
+	<rule ref="SlevomatCodingStandard.TypeHints.LongTypeHints"/>
+	<rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes"/>
+	<rule ref="SlevomatCodingStandard.TypeHints.ReturnTypeHint"/>
+	<rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHintSpacing"/>
+
+	<rule ref="SlevomatCodingStandard.Variables.DuplicateAssignmentToVariable"/>
+	<rule ref="SlevomatCodingStandard.Variables.UselessVariable"/>
+	<rule ref="SlevomatCodingStandard.Variables.UnusedVariable"/>
+	<rule ref="SlevomatCodingStandard.Variables.DisallowSuperGlobalVariable"/>
+
+	<rule ref="SlevomatCodingStandard.Whitespaces.DuplicateSpaces"/>
+
+</ruleset>

--- a/src/CallbackList.php
+++ b/src/CallbackList.php
@@ -1,22 +1,22 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace Sminnee\CallbackList;
+
+// @phpcs:disable SlevomatCodingStandard.TypeHints.DisallowMixedTypeHint.DisallowedMixedTypeHint
 
 /**
  * Manages a list of callbacks that can be called sequentially with {@link call()}
  */
 class CallbackList
 {
-    /**
-     * @var callable[]
-     */
+    /** @var array<callable> */
     private $callbacks = [];
 
     /**
      * Add a callback to the end of the list
      *
-     * @param $callback The callback to call. The arguments from {@link call()} will be passed
-     * @param $name An optional name to pass to get() and remove() in future
+     * @param callable $callback The callback to call. The arguments from {@link call()} will be passed
+     * @param string $name An optional name to pass to get() and remove() in future
      */
     public function add(callable $callback, ?string $name = null): void
     {
@@ -27,21 +27,24 @@ class CallbackList
         }
     }
 
+
     /**
      * Remove a named callback.
      *
-     * @param The name originally passed in add()
-     * @return True if successfully removed, false if not found
+     * @param string $name The name originally passed in add()
+     * @return bool True if successfully removed, false if not found
      */
     public function remove(string $name): bool
     {
-        if (!array_key_exists($name, $this->callbacks)) {
+        if (!\array_key_exists($name, $this->callbacks)) {
             return false;
         }
 
         unset($this->callbacks[$name]);
+
         return true;
     }
+
 
     /**
      * Clear the callback list
@@ -51,48 +54,60 @@ class CallbackList
         $this->callbacks = [];
     }
 
+
     /**
      * Get a named callback
      *
-     * @param The name originally passed in add()
-     * @return The blac
+     * @param string $name name originally passed in add()
+     * @return callable The callback
      */
     public function get(string $name): ?callable
     {
-        if (!array_key_exists($name, $this->callbacks)) {
+        if (!\array_key_exists($name, $this->callbacks)) {
             return null;
         }
 
         return $this->callbacks[$name];
     }
 
+
     /**
      * Get all callbacks
      *
-     * @return callable[]
+     * @return array<callable>
      */
     public function getAll(): array
     {
-        return array_values($this->callbacks);
+        return \array_values($this->callbacks);
     }
+
 
     /**
      * Call all the callbacks, passing the given arguments to each of them
+     *
+     * @param mixed ...$args
+     * @return array<mixed>
      */
     public function call(...$args): array
     {
+        /** @var array<mixed> $results */
         $results = [];
         foreach ($this->callbacks as $callback) {
-            $results[] = call_user_func_array($callback, $args);
+            $results[] = \call_user_func_array($callback, $args);
         }
+
         return $results;
     }
 
+
     /**
      * Treat CallbackList as a callable
+     *
+     * @param mixed ...$args
+     * @return array<mixed>
      */
     public function __invoke(...$args): array
     {
-        return call_user_func_array([$this, 'call'], $args);
+        return \call_user_func_array([$this, 'call'], $args);
     }
 }

--- a/tests/CallbackListTest.php
+++ b/tests/CallbackListTest.php
@@ -5,6 +5,7 @@ namespace Sminnee\CallbackList\Tests;
 use PHPUnit\Framework\TestCase;
 use Sminnee\CallbackList\CallbackList;
 
+/** @covers Sminnee\CallbackList\CallbackList */
 class CallbackListTest extends TestCase
 {
     public function testCallWithoutReturnVales(): void

--- a/tests/CallbackListTest.php
+++ b/tests/CallbackListTest.php
@@ -1,26 +1,26 @@
-<?php
+<?php declare(strict_types = 1);
 
 namespace Sminnee\CallbackList\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Sminnee\CallbackList\CallbackList;
 
-class CallbackLisTest extends TestCase
+class CallbackListTest extends TestCase
 {
-    public function testCallWithoutReturnVales()
+    public function testCallWithoutReturnVales(): void
     {
         $list = new CallbackList();
 
         $log = [];
 
         // Confirming that voids are allowed even though returns are collected
-        $list->add(function () use (&$log): void {
+        $list->add(static function () use (&$log): void {
             $log[] = 'a';
         });
-        $list->add(function () use (&$log): void {
+        $list->add(static function () use (&$log): void {
             $log[] = 'b';
         });
-        $list->add(function () use (&$log): void {
+        $list->add(static function () use (&$log): void {
             $log[] = 'c';
         });
 
@@ -29,45 +29,47 @@ class CallbackLisTest extends TestCase
         $this->assertEquals(['a', 'b', 'c'], $log);
     }
 
-    public function testCallReturnValues()
+
+    public function testCallReturnValues(): void
     {
         $list = new CallbackList();
 
-        $list->add(function () use (&$log) {
+        $list->add(static function () {
             return 'a';
         });
-        $list->add(function () use (&$log) {
+        $list->add(static function () {
             return 2;
         });
-        $list->add(function () use (&$log) {
+        $list->add(static function () {
             return ['c'];
         });
 
         // An array of return values, including mixed return types, is returned
         $this->assertEquals(
-            [ 'a', 2, ['c'] ],
+            ['a', 2, ['c']],
             $list->call()
         );
 
         // Check invoke syntax
         $this->assertEquals(
-            [ 'a', 2, ['c'] ],
+            ['a', 2, ['c']],
             $list()
         );
     }
 
-    public function testCallWithArgs()
+
+    public function testCallWithArgs(): void
     {
         $list = new CallbackList();
 
         $log = [];
-        $list->add(function ($greeting, $punctuation = '') use (&$log) {
+        $list->add(static function ($greeting, $punctuation = '') use (&$log): void {
             $log[] = "$greeting, a$punctuation";
         });
-        $list->add(function ($greeting, $punctuation = '') use (&$log) {
+        $list->add(static function ($greeting, $punctuation = '') use (&$log): void {
             $log[] = "$greeting, b$punctuation";
         });
-        $list->add(function ($greeting, $punctuation = '') use (&$log) {
+        $list->add(static function ($greeting, $punctuation = '') use (&$log): void {
             $log[] = "$greeting, c$punctuation";
         });
 
@@ -89,12 +91,13 @@ class CallbackLisTest extends TestCase
         $this->assertEquals(['Hello, a!', 'Hello, b!', 'Hello, c!'], $log);
     }
 
-    public function testGetAll()
+
+    public function testGetAll(): void
     {
-        $a = function () {
+        $a = static function (): void {
             echo 'a';
         };
-        $b = function () {
+        $b = static function (): void {
             echo 'b';
         };
 
@@ -105,12 +108,13 @@ class CallbackLisTest extends TestCase
         $this->assertEquals([$a, $b], $list->getAll());
     }
 
-    public function testGetNamed()
+
+    public function testGetNamed(): void
     {
-        $a = function () {
+        $a = static function (): void {
             echo 'a';
         };
-        $b = function () {
+        $b = static function (): void {
             echo 'b';
         };
 
@@ -122,12 +126,13 @@ class CallbackLisTest extends TestCase
         $this->assertEquals($a, $list->get('b'));
     }
 
-    public function testRemoveNamed()
+
+    public function testRemoveNamed(): void
     {
-        $a = function () {
+        $a = static function (): void {
             echo 'a';
         };
-        $b = function () {
+        $b = static function (): void {
             echo 'b';
         };
 
@@ -139,15 +144,16 @@ class CallbackLisTest extends TestCase
         $this->assertEquals([$b], $list->getAll());
     }
 
-    public function testClear()
+
+    public function testClear(): void
     {
-        $a = function () {
+        $a = static function (): void {
             echo 'a';
         };
-        $b = function () {
+        $b = static function (): void {
             echo 'b';
         };
-        $c = function () {
+        $c = static function (): void {
             echo 'c';
         };
 
@@ -160,20 +166,22 @@ class CallbackLisTest extends TestCase
         $this->assertEquals([$c], $list->getAll());
     }
 
-    public function testCallbackIsACallable()
+
+    public function testCallbackIsACallable(): void
     {
         $list = new CallbackList();
 
-        $this->assertTrue(is_callable($list));
+        $this->assertTrue(\is_callable($list));
 
-        $test = function (callable $x) {
+        $test = static function (callable $x) {
             return $x();
         };
 
         $this->assertEquals($list(), $test($list));
     }
 
-    public function testEmptyList()
+
+    public function testEmptyList(): void
     {
         $list = new CallbackList();
         $this->assertEquals([], $list());


### PR DESCRIPTION
hi Sam,

This is a tool I originally wrote to tidy up some old (and new) SilverStripe modules so that strict coding standards are adhered to - https://github.com/gordonbanderson/php-travis-enhancer

Given this module was only a couple of files I decided to run the enhancer tool over this.   It adds the following checks:

* Slevomat Coding Standards - a selection thereof, as some break PHP 7.1
* PHPStan - static analysis tool
* Psalm - ditto
* PHP Linting - check for syntax errors
* JSCPD - Code duplication check

This was actually the first project I've tried where duplication was picked up, and it didn't fail the build initially, due to a missing threshold parameter :( 

One other tool that could be added to the mix is leasot, which one can configure to fail a build if FIXME or TODO comments are found.


I have tried updating a couple of large PHP projects to comply, it's a lot of effort.  But for small modules or new modules started from scratch , I am finding it useful.  

Cheers

Gordon

PS I 've updated the README badges, but the Scrutinizer badge is not working.  I guess the project has not been submitted to Scrutinizer, as such either submit it or remove the badge.

