### PR TITLE
Use caret for PHP8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": "^7.1 || 8"
+        "php": "^7.1 || ^8"
     },
     "require-dev": {
         "phpunit/phpunit": "^7 || ^8 || ^9",


### PR DESCRIPTION
Use caret for PHP8 now that PHP 8.0.1-dev is the "nightly" edition